### PR TITLE
Suggestion for api structure

### DIFF
--- a/bruno/Test Endpoint.bru
+++ b/bruno/Test Endpoint.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Test Endpoint
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:3001/api/test
+  body: none
+  auth: inherit
+}

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,15 @@
+{
+  "version": "1",
+  "name": "PoS System",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ],
+  "size": 0,
+  "filesCount": 0,
+  "presets": {
+    "requestType": "http",
+    "requestUrl": "http://localhost:3001"
+  }
+}

--- a/web/src/app/api/test/route.tsx
+++ b/web/src/app/api/test/route.tsx
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export async function GET(_: NextRequest) {
+  return NextResponse.json({ message: 'Hello from App Router API!' })
+}
+
+export async function POST(request: NextRequest) {
+  const data = await request.json()
+  return NextResponse.json({ received: data })
+}


### PR DESCRIPTION
Each endpoint (i.e "api/users", "api/products") ay ilalagay nang ganto sa directory, with a route.tsx file inside.
<pre><code>app/
└── api/
    ├── some-endpoint/
    │  └── route.tsx 
    └── other-endpoint/
        └── [id]/
            └── route.tsx</code></pre>

Tas inside route.tsx, we'd define ung mga different methods (i.e GET, POST) like this:
```tsx
// src\app\api\test\route.tsx

import { NextResponse } from 'next/server'
import type { NextRequest } from 'next/server'

export async function GET(_: NextRequest) {
  return NextResponse.json({ message: 'Hello from App Router API!' })
}

export async function POST(request: NextRequest) {
  const data = await request.json()
  return NextResponse.json({ received: data })
}
```

Then we'd hit that endpoint thru "/api/test"

P.S: Ung bruno folder is autogenerated ng api testing software na gamit ko. Lemme know if i-gitignore ko siya or gusto mo ren gamitin.
